### PR TITLE
Fixing __lt__ comparison in GF2

### DIFF
--- a/lightsout.py
+++ b/lightsout.py
@@ -49,7 +49,7 @@ class GF2(object):
     
     def __lt__(self, rhs):
         if isinstance(rhs, GF2):
-            return self.value <= rhs.value
+            return self.value < rhs.value
         return self.value < rhs
     
     def __int__(self):


### PR DESCRIPTION
The less-than comparison was checking less-than-or-equal in the case that the right-hand-side was also of type, GF2.
